### PR TITLE
Fix crash in python3 when trying to reload config

### DIFF
--- a/source/easyleed/gui.py
+++ b/source/easyleed/gui.py
@@ -9,6 +9,7 @@ import webbrowser
 import pickle
 import six
 import time
+import imp
 
 from .qt import get_qt_binding_name, qt_filedialog_convert
 from .qt.QtCore import (QPoint, QRectF, QPointF, Qt, QTimer, QObject)
@@ -671,7 +672,7 @@ class ParameterSettingWidget(QWidget):
 
     def defaultValues(self):
         """Reload config-module and get the default values"""
-        reload(config)
+        imp.reload(config)
         self.inputPrecision.setValue(config.Tracking_inputPrecision)
         self.integrationWindowRadiusNew.setValue(config.GraphicsScene_defaultRadius)
         self.integrationWindowRadius.setValue(config.Tracking_minWindowSize)


### PR DESCRIPTION
reload method in python2 is no longer available in python3. The call in
gui.py defaultValues(self) uses it to restore the config parameters.
Practically, from the parameter settings, when pushing "Default", easyleed
crashes when used with Python3. The proposed patch fixes it by using the
new implementation of reload through imp.reload. This has also being backported
to python2, so it should be safe for both.