### PR TITLE
Use parser for storing software config parameters

### DIFF
--- a/source/easyleed/__init__.py
+++ b/source/easyleed/__init__.py
@@ -23,15 +23,21 @@ The EasyLEED package is divided into several subpackages:
 __version__ = "2.3.4"
 __author__ = "Andreas Mayer, Hanna Salopaasi, Nicola Ferralis"
 
-# import packages
-try:
-    import easyleedconfig as config
-except:
-    from . import defaultconfig as config
+from .defaultconfig import *
+import os.path
+
+config = Configuration()
+if os.path.isfile(config.configFile) is False:
+    print("Configuration file does not exist: Creating one.")
+    config.createConfig()
+config.readConfig(config.configFile)
 
 import logging
-logging.basicConfig(filename=config.loggingFilename, level=config.loggingLevel)
+logging.basicConfig(filename=config.loggingFilename, level=int(config.loggingLevel))
 logger = logging.getLogger()
+
+from . import defaultconfig
+from . import gui
 
 from . import kalman
 from . import io

--- a/source/easyleed/defaultconfig.py
+++ b/source/easyleed/defaultconfig.py
@@ -1,8 +1,9 @@
 '''
 configuration
 ------------------
-Class for handling configuration
+Class for handling configuration settings
 '''
+
 import configparser, logging, os
 import numpy as np
 from pathlib import Path
@@ -11,13 +12,13 @@ from . import __version__
 class Configuration():
     def __init__(self):
         self.home = str(Path.home())+"/"
-        self.configFile = str(self.home+"easyleed.ini")
-        self.loggingFilename = str("easyleed.log")
+        self.configFile = self.home+"easyleed.ini"
+        self.loggingFilename = "easyleed.log"
         self.conf = configparser.ConfigParser()
         self.conf.optionxform = str
     
-    # Create configuration file
     def createConfig(self):
+        """Create configuration file"""
         try:
             self.defineIOConfig()
             self.defineGUIConfig()
@@ -29,7 +30,7 @@ class Configuration():
         except:
             print("Error in creating configuration file")
 
-    # Hadrcoded default definitions for the confoguration file
+    # Hardcoded default definitions for the configuration file
     def defineIOConfig(self):
         self.conf['IO'] = {
             'IO_energyRegex' : "[0-9]+(\.[0-9]*)?([Ee](|\+|-)[0-9]+)?(?=[^.0-9]*\.[A-Za-z0-9]+$)",
@@ -103,70 +104,68 @@ class Configuration():
         #####################
         ## GraphicsScene ##
         # default radius of a new spot
-        self.GraphicsScene_defaultRadius = eval(self.GUIConfig['GraphicsScene_defaultRadius'])
+        self.GraphicsScene_defaultRadius = self.conf.getfloat('GUI', 'GraphicsScene_defaultRadius')
         # Live IV plotting during acquisition
-        self.GraphicsScene_livePlottingOn = eval(self.GUIConfig['GraphicsScene_livePlottingOn'])
+        self.GraphicsScene_livePlottingOn = self.conf.getboolean('GUI', 'GraphicsScene_livePlottingOn')
         # Acquire I(time) at fixed energy
-        self.GraphicsScene_intensTimeOn = eval(self.GUIConfig['GraphicsScene_intensTimeOn'])
+        self.GraphicsScene_intensTimeOn = self.conf.getboolean('GUI', 'GraphicsScene_intensTimeOn')
         # Plot averages
-        self.GraphicsScene_plotAverage = eval(self.GUIConfig['GraphicsScene_plotAverage'])
+        self.GraphicsScene_plotAverage = self.conf.getboolean('GUI', 'GraphicsScene_plotAverage')
         # Plot smoothAverages
-        self.GraphicsScene_plotSmoothAverage = eval(self.GUIConfig['GraphicsScene_plotSmoothAverage'])
+        self.GraphicsScene_plotSmoothAverage = self.conf.getboolean('GUI', 'GraphicsScene_plotSmoothAverage')
         # Interval of points to be rescaled for smoothing average
-        self.GraphicsScene_smoothPoints = eval(self.GUIConfig['GraphicsScene_smoothPoints'])
+        self.GraphicsScene_smoothPoints = self.conf.getint('GUI', 'GraphicsScene_smoothPoints')
         # Amount of smoothing to perform during the spline fit.
         # The default value of s is s=m-\sqrt{2m} where m is the number of data-points being fit.
-        self.GraphicsScene_smoothSpline = eval(self.GUIConfig['GraphicsScene_smoothSpline'])
+        self.GraphicsScene_smoothSpline = self.conf.getint('GUI', 'GraphicsScene_smoothSpline')
 
         ## QGraphicsMovableItem ##
         # change in position per key press (Arrow keys)
-        self.QGraphicsMovableItem_bigMove = eval(self.GUIConfig['QGraphicsMovableItem_bigMove'])
+        self.QGraphicsMovableItem_bigMove = self.conf.getfloat('GUI', 'QGraphicsMovableItem_bigMove')
         # change in position per key press if Ctrl pressed
-        self.QGraphicsMovableItem_smallMove = eval(self.GUIConfig['QGraphicsMovableItem_smallMove'])
+        self.QGraphicsMovableItem_smallMove = self.conf.getfloat('GUI', 'QGraphicsMovableItem_smallMove')
 
         ## QGraphicsSpotItem ##
         # change in radius of the spot per key press (+/-) in pixel
-        self.QGraphicsSpotItem_spotSizeChange = eval(self.GUIConfig['QGraphicsSpotItem_spotSizeChange'])
+        self.QGraphicsSpotItem_spotSizeChange = self.conf.getfloat('GUI', 'QGraphicsSpotItem_spotSizeChange')
 
         ## QGraphicsCenterItem ##
-        self.QGraphicsCenterItem_size = eval(self.GUIConfig['QGraphicsCenterItem_size'])
+        self.QGraphicsCenterItem_size = self.conf.getfloat('GUI', 'QGraphicsCenterItem_size')
 
         ##########################
         #### Tracking related ####
         ##########################
 
         # precision of the user input (standard deviation in pixel)
-        self.Tracking_inputPrecision = eval(self.trackingConfig['Tracking_inputPrecision'])
+        self.Tracking_inputPrecision = self.conf.getfloat('Tracking', 'Tracking_inputPrecision')
         # scale the integration window with changing energy
-        self.Tracking_windowScalingOn = eval(self.trackingConfig['Tracking_windowScalingOn'])
+        self.Tracking_windowScalingOn = self.conf.getboolean('Tracking', 'Tracking_windowScalingOn')
         # minimal radius of the integration window (in pixel)
-        self.Tracking_minWindowSize = eval(self.trackingConfig['Tracking_minWindowSize'])
+        self.Tracking_minWindowSize = self.conf.getfloat('Tracking', 'Tracking_minWindowSize')
         # function for spot identification
         self.Tracking_guessFunc = self.trackingConfig['Tracking_guessFunc']
         # Kalman tracker process noise
-        self.Tracking_processNoisePosition = eval(self.trackingConfig['Tracking_processNoisePosition'])
-        self.Tracking_processNoiseVelocity = eval(self.trackingConfig['Tracking_processNoiseVelocity'])
+        self.Tracking_processNoisePosition = self.conf.getfloat('Tracking', 'Tracking_processNoisePosition')
+        self.Tracking_processNoiseVelocity = self.conf.getfloat('Tracking', 'Tracking_processNoiseVelocity')
         # size of validation region
         # Ideal assumptions D_M^2 ~ Chi^2 with two degrees of freedom
         # cdf Chi^2 with two degrees of freedom is 1 - exp(-x/2)
-        self.Tracking_gamma = eval(self.trackingConfig['Tracking_gamma'])
+        self.Tracking_gamma = self.conf.getfloat('Tracking', 'Tracking_gamma')
         # Minimal coefficient of determination R^2 for fit
-        self.Tracking_minRsq = eval(self.trackingConfig['Tracking_minRsq'])
+        self.Tracking_minRsq = self.conf.getfloat('Tracking', 'Tracking_minRsq')
         # factor by which the fitted region is bigger than the radius
-        self.Tracking_fitRegionFactor = eval(self.trackingConfig['Tracking_fitRegionFactor'])
+        self.Tracking_fitRegionFactor = self.conf.getfloat('Tracking', 'Tracking_fitRegionFactor')
 
         ############################
         #### Processing related ####
         ############################
         # substract the background from the intensity measurements
-        self.Processing_backgroundSubstractionOn = eval(self.processingConfig['Processing_backgroundSubstractionOn'])
+        self.Processing_backgroundSubstractionOn = self.conf.getboolean('Processing', 'Processing_backgroundSubstractionOn')
         
         ############################
         #### System related ####
         ############################
-        # substract the background from the intensity measurements
-        self.loggingLevel = eval(self.sysConfig['loggingLevel'])
-        self.loggingLevel = eval(self.sysConfig['loggingLevel'])
+        self.loggingLevel = self.conf.getint('System', 'loggingLevel')
 
     # Save current parameters in configuration file
     def saveConfig(self, configFile):

--- a/source/easyleed/defaultconfig.py
+++ b/source/easyleed/defaultconfig.py
@@ -1,84 +1,177 @@
-# how much information shall be logged
-import logging
-loggingLevel = logging.INFO
-loggingFilename = "easyleed.log"
-
+'''
+configuration
+------------------
+Class for handling configuration
+'''
+import configparser, logging, os
 import numpy as np
+from pathlib import Path
+from . import __version__
 
-#### IO related ####
-####################
+class Configuration():
+    def __init__(self):
+        self.home = str(Path.home())+"/"
+        self.configFile = str(self.home+"easyleed.ini")
+        self.loggingFilename = str("easyleed.log")
+        self.conf = configparser.ConfigParser()
+        self.conf.optionxform = str
+    
+    # Create configuration file
+    def createConfig(self):
+        try:
+            self.defineIOConfig()
+            self.defineGUIConfig()
+            self.defineTrackingConfig()
+            self.defineProcessingConfig()
+            self.defineSystemConfig()
+            with open(self.configFile, 'w') as configfile:
+                self.conf.write(configfile)
+        except:
+            print("Error in creating configuration file")
 
-# regular expression to extract energy from filename (not used for img files)
-# match the last (floating-point) number before file extension
-IO_energyRegex = "[0-9]+(\.[0-9]*)?([Ee](|\+|-)[0-9]+)?(?=[^.0-9]*\.[A-Za-z0-9]+$)"
+    # Hadrcoded default definitions for the confoguration file
+    def defineIOConfig(self):
+        self.conf['IO'] = {
+            'IO_energyRegex' : "[0-9]+(\.[0-9]*)?([Ee](|\+|-)[0-9]+)?(?=[^.0-9]*\.[A-Za-z0-9]+$)",
+            }
+    def defineGUIConfig(self):
+        self.conf['GUI'] = {
+            'GraphicsScene_defaultRadius' : 40,
+            'GraphicsScene_livePlottingOn' : True,
+            'GraphicsScene_intensTimeOn' : False,
+            'GraphicsScene_plotAverage' : False,
+            'GraphicsScene_plotSmoothAverage': False,
+            'GraphicsScene_smoothPoints' : 4,
+            'GraphicsScene_smoothSpline' : 50,
+            'QGraphicsMovableItem_bigMove' : 1,
+            'QGraphicsMovableItem_smallMove' : 0.1,
+            'QGraphicsSpotItem_spotSizeChange' : 1,
+            'QGraphicsCenterItem_size' : 5,
+            }
+    def defineTrackingConfig(self):
+        self.conf['Tracking'] = {
+            'Tracking_inputPrecision' : 2,
+            'Tracking_windowScalingOn' : True,
+            'Tracking_minWindowSize' : 0,
+            'Tracking_guessFunc' : "guess_from_Gaussian",
+            'Tracking_processNoisePosition' : 0.1,
+            'Tracking_processNoiseVelocity' : 0.0,
+            'Tracking_gamma' : 8,
+            'Tracking_minRsq' : 0.8,
+            'Tracking_fitRegionFactor' : 1.5,
+            }
+    
+    def defineProcessingConfig(self):
+        self.conf['Processing'] = {
+            'Processing_backgroundSubstractionOn' : True,
+            }
+    
+    def defineSystemConfig(self):
+        self.conf['System'] = {
+            'appVersion' : __version__,
+            'loggingLevel' : logging.INFO,
+            'loggingFilename' : self.loggingFilename,
+            }
 
-####################
-####################
+    # Read configuration file into usable variables
+    def readConfig(self, configFile):
+        self.conf.read(configFile)
+        self.sysConfig = self.conf['System']
+        self.appVersion = self.sysConfig['appVersion']
+        if str(self.appVersion).rsplit('.',1)[0] != __version__.rsplit('.',1)[0] :
+            print("Configuration file is for an earlier version of the software")
+            oldConfigFile = str(os.path.splitext(configFile)[0]+"_"+str(self.appVersion)+".ini")
+            print("Old config file backup: ",oldConfigFile)
+            os.rename(configFile, oldConfigFile )
+            print("Creating a new config file.")
+            self.createConfig()
+            
+        self.IOConfig = self.conf['IO']
+        self.GUIConfig = self.conf['GUI']
+        self.trackingConfig = self.conf['Tracking']
+        self.processingConfig = self.conf['Processing']
 
-#### GUI related ####
-#####################
+        #####################
+        #### IO related ####
+        ####################
+        # regular expression to extract energy from filename (not used for img files)
+        # match the last (floating-point) number before file extension
+        self.IO_energyRegex = self.IOConfig['IO_energyRegex']
 
-## GraphicsScene ##
-# default radius of a new spot
-GraphicsScene_defaultRadius = 40
-# Live IV plotting during acquisition
-GraphicsScene_livePlottingOn = True
-# Acquire I(time) at fixed energy
-GraphicsScene_intensTimeOn = False
-# Plot averages
-GraphicsScene_plotAverage = False
-# Plot smoothAverages
-GraphicsScene_plotSmoothAverage = False
-# Interval of points to be rescaled for smoothing average
-GraphicsScene_smoothPoints = 4
-# Amount of smoothing to perform during the spline fit.
-# The default value of s is s=m-\sqrt{2m} where m is the number of data-points being fit.
-GraphicsScene_smoothSpline = 50
+        #####################
+        #### GUI related ####
+        #####################
+        ## GraphicsScene ##
+        # default radius of a new spot
+        self.GraphicsScene_defaultRadius = eval(self.GUIConfig['GraphicsScene_defaultRadius'])
+        # Live IV plotting during acquisition
+        self.GraphicsScene_livePlottingOn = eval(self.GUIConfig['GraphicsScene_livePlottingOn'])
+        # Acquire I(time) at fixed energy
+        self.GraphicsScene_intensTimeOn = eval(self.GUIConfig['GraphicsScene_intensTimeOn'])
+        # Plot averages
+        self.GraphicsScene_plotAverage = eval(self.GUIConfig['GraphicsScene_plotAverage'])
+        # Plot smoothAverages
+        self.GraphicsScene_plotSmoothAverage = eval(self.GUIConfig['GraphicsScene_plotSmoothAverage'])
+        # Interval of points to be rescaled for smoothing average
+        self.GraphicsScene_smoothPoints = eval(self.GUIConfig['GraphicsScene_smoothPoints'])
+        # Amount of smoothing to perform during the spline fit.
+        # The default value of s is s=m-\sqrt{2m} where m is the number of data-points being fit.
+        self.GraphicsScene_smoothSpline = eval(self.GUIConfig['GraphicsScene_smoothSpline'])
 
-## QGraphicsMovableItem ##
-# change in position per key press (Arrow keys)
-QGraphicsMovableItem_bigMove = 1
-# change in position per key press if Ctrl pressed
-QGraphicsMovableItem_smallMove = 0.1
+        ## QGraphicsMovableItem ##
+        # change in position per key press (Arrow keys)
+        self.QGraphicsMovableItem_bigMove = eval(self.GUIConfig['QGraphicsMovableItem_bigMove'])
+        # change in position per key press if Ctrl pressed
+        self.QGraphicsMovableItem_smallMove = eval(self.GUIConfig['QGraphicsMovableItem_smallMove'])
 
-## QGraphicsSpotItem ##
-# change in radius of the spot per key press (+/-) in pixel
-QGraphicsSpotItem_spotSizeChange = 1
+        ## QGraphicsSpotItem ##
+        # change in radius of the spot per key press (+/-) in pixel
+        self.QGraphicsSpotItem_spotSizeChange = eval(self.GUIConfig['QGraphicsSpotItem_spotSizeChange'])
 
-## QGraphicsCenterItem ##
-QGraphicsCenterItem_size = 5
+        ## QGraphicsCenterItem ##
+        self.QGraphicsCenterItem_size = eval(self.GUIConfig['QGraphicsCenterItem_size'])
 
-######################
-######################
+        ##########################
+        #### Tracking related ####
+        ##########################
 
-#### Tracking related ####
-##########################
+        # precision of the user input (standard deviation in pixel)
+        self.Tracking_inputPrecision = eval(self.trackingConfig['Tracking_inputPrecision'])
+        # scale the integration window with changing energy
+        self.Tracking_windowScalingOn = eval(self.trackingConfig['Tracking_windowScalingOn'])
+        # minimal radius of the integration window (in pixel)
+        self.Tracking_minWindowSize = eval(self.trackingConfig['Tracking_minWindowSize'])
+        # function for spot identification
+        self.Tracking_guessFunc = self.trackingConfig['Tracking_guessFunc']
+        # Kalman tracker process noise
+        self.Tracking_processNoisePosition = eval(self.trackingConfig['Tracking_processNoisePosition'])
+        self.Tracking_processNoiseVelocity = eval(self.trackingConfig['Tracking_processNoiseVelocity'])
+        # size of validation region
+        # Ideal assumptions D_M^2 ~ Chi^2 with two degrees of freedom
+        # cdf Chi^2 with two degrees of freedom is 1 - exp(-x/2)
+        self.Tracking_gamma = eval(self.trackingConfig['Tracking_gamma'])
+        # Minimal coefficient of determination R^2 for fit
+        self.Tracking_minRsq = eval(self.trackingConfig['Tracking_minRsq'])
+        # factor by which the fitted region is bigger than the radius
+        self.Tracking_fitRegionFactor = eval(self.trackingConfig['Tracking_fitRegionFactor'])
 
-# precision of the user input (standard deviation in pixel)
-Tracking_inputPrecision = 2
-# scale the integration window with changing energy
-Tracking_windowScalingOn = True
-# minimal radius of the integration window (in pixel)
-Tracking_minWindowSize = 0
-# function for spot identification
-Tracking_guessFunc = "guess_from_Gaussian"
-# Kalman tracker process noise
-Tracking_processNoisePosition = 0.1
-Tracking_processNoiseVelocity = 0.0
-# size of validation region
-# Ideal assumptions D_M^2 ~ Chi^2 with two degrees of freedom
-# cdf Chi^2 with two degrees of freedom is 1 - exp(-x/2)
-Tracking_gamma = 8
-# Minimal coefficient of determination R^2 for fit
-Tracking_minRsq = 0.8
-# factor by which the fitted region is bigger than the radius
-Tracking_fitRegionFactor = 1.5
+        ############################
+        #### Processing related ####
+        ############################
+        # substract the background from the intensity measurements
+        self.Processing_backgroundSubstractionOn = eval(self.processingConfig['Processing_backgroundSubstractionOn'])
+        
+        ############################
+        #### System related ####
+        ############################
+        # substract the background from the intensity measurements
+        self.loggingLevel = eval(self.sysConfig['loggingLevel'])
+        self.loggingLevel = eval(self.sysConfig['loggingLevel'])
 
-##########################
-##########################
-
-#### Processing related ####
-############################
-
-# substract the background from the intensity measurements
-Processing_backgroundSubstractionOn = True
+    # Save current parameters in configuration file
+    def saveConfig(self, configFile):
+        try:
+            with open(configFile, 'w') as configfile:
+                self.conf.write(configfile)
+        except:
+            print("Error in saving parameters")

--- a/source/easyleed/gui.py
+++ b/source/easyleed/gui.py
@@ -736,8 +736,8 @@ class ParameterSettingWidget(QWidget):
                         "Save INI config file", "","*.ini")
         self.collectParameters()
         config.saveConfig(filename[0])
-        print("Confguration parameters saved to:",filename[0])
-        logger.info("Confguration parameters saved to:"+filename[0])
+        print("Configuration parameters saved to:",filename[0])
+        logger.info("Configuration parameters saved to:"+filename[0])
 
     def loadValues(self):
         """ Load a file of set parameter values that has been saved with the widget """
@@ -746,8 +746,8 @@ class ParameterSettingWidget(QWidget):
                         "Open INI config file", "","*.ini")
         try:
             config.readConfig(filename)
-            print("Confguration parameters loaded from:",filename[0])
-            logger.info("Confguration parameters loaded from:"+filename[0])
+            print("Configuration parameters loaded from:",filename[0])
+            logger.info("Configuration parameters loaded from:"+filename[0])
         except:
             print("Invalid file")
 

--- a/source/easyleed/gui.py
+++ b/source/easyleed/gui.py
@@ -482,71 +482,86 @@ class ParameterSettingWidget(QWidget):
         self.inputPrecision.setWrapping(True)
         self.inputPrecision.setValue(config.Tracking_inputPrecision)
         self.ipLabel = QLabel("User input precision", self)
+        self.inputPrecision.editingFinished.connect(self.collectParameters)
 
         self.integrationWindowRadiusNew = QSpinBox(self)
         self.integrationWindowRadiusNew.setWrapping(True)
         self.integrationWindowRadiusNew.setValue(config.GraphicsScene_defaultRadius)
         self.iwrnLabel = QLabel("Default radius of a new spot", self)
+        self.integrationWindowRadiusNew.editingFinished.connect(self.collectParameters)
 
         self.integrationWindowRadius = QSpinBox(self)
         self.integrationWindowRadius.setWrapping(True)
         self.integrationWindowRadius.setValue(config.Tracking_minWindowSize)
         self.iwrLabel = QLabel("Minimal radius of the integration window", self)
+        self.integrationWindowRadius.editingFinished.connect(self.collectParameters)
 
         self.validationRegionSize = QSpinBox(self)
         self.validationRegionSize.setWrapping(True)
         self.validationRegionSize.setValue(config.Tracking_gamma)
         self.vrsLabel = QLabel("Size of the validation region", self)
+        self.validationRegionSize.editingFinished.connect(self.collectParameters)
 
         self.determinationCoefficient = QDoubleSpinBox(self)
         self.determinationCoefficient.setWrapping(True)
         self.determinationCoefficient.setSingleStep(0.01)
         self.determinationCoefficient.setValue(config.Tracking_minRsq)
         self.dcLabel = QLabel("Minimal R" + chr(0x00B2) + " to accept fit", self)
+        self.determinationCoefficient.editingFinished.connect(self.collectParameters)
 
         self.integrationWindowScale = QCheckBox("Scale integration window with changing energy")
         self.integrationWindowScale.setChecked(config.Tracking_windowScalingOn)
+        self.integrationWindowScale.stateChanged.connect(self.collectParameters)
 
         self.backgroundSubstraction = QCheckBox("Background substraction")
         self.backgroundSubstraction.setChecked(config.Processing_backgroundSubstractionOn)
+        self.backgroundSubstraction.stateChanged.connect(self.collectParameters)
 
         self.livePlotting = QCheckBox("Plot I(E) intensities during acquisition")
         self.livePlotting.setChecked(config.GraphicsScene_livePlottingOn)
+        self.livePlotting.stateChanged.connect(self.collectParameters)
 
         self.intensTime = QCheckBox("Extract I(frame) - fixed energy")
         self.intensTime.setChecked(config.GraphicsScene_intensTimeOn)
+        self.intensTime.stateChanged.connect(self.collectParameters)
 
         self.smoothPoints = QSpinBox(self)
         self.smoothPoints.setWrapping(True)
         self.smoothPoints.setToolTip("Press Enter to update plot")
         self.smoothPoints.setValue(config.GraphicsScene_smoothPoints)
         self.smPoiLabel = QLabel("# points to be rescaled for smoothing", self)
+        self.smoothPoints.editingFinished.connect(self.collectParameters)
 
         self.smoothSpline = QSpinBox(self)
         self.smoothSpline.setWrapping(True)
         self.smoothSpline.setToolTip("Press Enter to update plot")
         self.smoothSpline.setValue(config.GraphicsScene_smoothSpline)
         self.smSplLabel = QLabel("Amount of smoothing to perform", self)
+        self.smoothSpline.editingFinished.connect(self.collectParameters)
 
         self.spotIdentification = QComboBox(self)
         self.spotIdentification.addItem("guess_from_Gaussian")
         self.siLabel = QLabel("Spot ident. algorithm", self)
+        self.spotIdentification.currentIndexChanged.connect(self.collectParameters)
 
         self.fnLabel = QLabel("Kalman tracker process noise Q", self)
         self.processNoisePosition = QDoubleSpinBox(self)
         self.processNoisePosition.setSingleStep(0.1)
         self.processNoisePosition.setValue(config.Tracking_processNoisePosition)
         self.processNoisePositionLabel = QLabel("Position", self)
+        self.processNoisePosition.editingFinished.connect(self.collectParameters)
+        
         self.processNoiseVelocity = QDoubleSpinBox(self)
         self.processNoiseVelocity.setSingleStep(0.1)
         self.processNoiseVelocity.setValue(config.Tracking_processNoiseVelocity)
         self.processNoiseVelocityLabel = QLabel("Velocity", self)
+        self.processNoiseVelocity.editingFinished.connect(self.collectParameters)
 
         self.saveButton = QPushButton('&Save', self)
         self.loadButton = QPushButton('&Load', self)
-        self.defaultButton = QPushButton('&Default', self)
+        self.defaultButton = QPushButton('&Restore Default', self)
         self.wrongLabel = QLabel(" ", self)
-        self.applyButton = QPushButton('&Apply', self)
+        self.applyButton = QPushButton('&Save as Default', self)
 
         self.vertLine = QFrame()
         self.vertLine.setFrameStyle(QFrame.VLine)
@@ -654,13 +669,10 @@ class ParameterSettingWidget(QWidget):
     def collectParameters(self):
         """Parameter setting control"""
         config.GraphicsScene_defaultRadius = self.integrationWindowRadiusNew.value()
-        config.GraphicsScene_livePlottingOn = self.livePlotting.isChecked()
-        config.GraphicsScene_intensTimeOn = self.intensTime.isChecked()
         config.GraphicsScene_smoothPoints = self.smoothPoints.value()
         config.GraphicsScene_smoothSpline = self.smoothSpline.value()
         
         config.Tracking_inputPrecision = self.inputPrecision.value()
-        config.Tracking_windowScalingOn = self.integrationWindowScale.isChecked()
         config.Tracking_minWindowSize = self.integrationWindowRadius.value()
         config.Tracking_guessFunc = self.spotIdentification.currentText()
         config.Tracking_processNoisePosition = self.processNoisePosition.value()
@@ -668,6 +680,13 @@ class ParameterSettingWidget(QWidget):
         config.Tracking_gamma = self.validationRegionSize.value()
         config.Tracking_minRsq = self.determinationCoefficient.value()
 
+    def applyParameters(self):
+        """Parameter setting control"""
+        self.collectParameters()
+        
+        config.GraphicsScene_livePlottingOn = self.livePlotting.isChecked()
+        config.GraphicsScene_intensTimeOn = self.intensTime.isChecked()
+        config.Tracking_windowScalingOn = self.integrationWindowScale.isChecked()
         config.Processing_backgroundSubstractionOn = self.backgroundSubstraction.isChecked()
 
         config.conf['GUI']['GraphicsScene_defaultRadius'] = str(config.GraphicsScene_defaultRadius)
@@ -686,11 +705,9 @@ class ParameterSettingWidget(QWidget):
         config.conf['Tracking']['Tracking_minRsq'] = str(config.Tracking_minRsq)
     
         config.conf['Processing']['Processing_backgroundSubstractionOn'] = str(config.Processing_backgroundSubstractionOn)
-
-    def applyParameters(self):
-        """Parameter setting control"""
-        self.collectParameters()
+        
         config.saveConfig(config.configFile)
+        logger.info("Current acquisition parameters set as default")
 
     def defaultValues(self):
         # Set default acquisition parameters from configuration ini
@@ -704,12 +721,12 @@ class ParameterSettingWidget(QWidget):
         self.determinationCoefficient.setValue(config.Tracking_minRsq)
         self.smoothPoints.setValue(config.GraphicsScene_smoothPoints)
         self.smoothSpline.setValue(config.GraphicsScene_smoothSpline)
+        self.processNoisePosition.setValue(config.Tracking_processNoisePosition)
+        self.processNoiseVelocity.setValue(config.Tracking_processNoiseVelocity)
         self.intensTime.setChecked(config.GraphicsScene_intensTimeOn)
         self.integrationWindowScale.setChecked(config.Tracking_windowScalingOn)
         self.backgroundSubstraction.setChecked(config.Processing_backgroundSubstractionOn)
         self.livePlotting.setChecked(config.GraphicsScene_livePlottingOn)
-        self.processNoisePosition.setValue(config.Tracking_processNoisePosition)
-        self.processNoiseVelocity.setValue(config.Tracking_processNoiseVelocity)
         logger.info("Default acquisition parameters restored")
 
     def saveValues(self):

--- a/source/easyleed/gui.py
+++ b/source/easyleed/gui.py
@@ -9,7 +9,6 @@ import webbrowser
 import pickle
 import six
 import time
-import imp
 
 from .qt import get_qt_binding_name, qt_filedialog_convert
 from .qt.QtCore import (QPoint, QRectF, QPointF, Qt, QTimer, QObject)
@@ -652,27 +651,52 @@ class ParameterSettingWidget(QWidget):
         self.saveButton.clicked.connect(self.saveValues)
         self.loadButton.clicked.connect(self.loadValues)
 
-    def applyParameters(self):
+    def collectParameters(self):
         """Parameter setting control"""
+        config.GraphicsScene_defaultRadius = self.integrationWindowRadiusNew.value()
+        config.GraphicsScene_livePlottingOn = self.livePlotting.isChecked()
+        config.GraphicsScene_intensTimeOn = self.intensTime.isChecked()
+        config.GraphicsScene_smoothPoints = self.smoothPoints.value()
+        config.GraphicsScene_smoothSpline = self.smoothSpline.value()
+        
         config.Tracking_inputPrecision = self.inputPrecision.value()
         config.Tracking_windowScalingOn = self.integrationWindowScale.isChecked()
         config.Tracking_minWindowSize = self.integrationWindowRadius.value()
-        config.GraphicsScene_defaultRadius = self.integrationWindowRadiusNew.value()
-        config.Tracking_minWindowSize = self.integrationWindowRadius.value()
         config.Tracking_guessFunc = self.spotIdentification.currentText()
-        config.Tracking_gamma = self.validationRegionSize.value()
-        config.Tracking_minRsq = self.determinationCoefficient.value()
-        config.Processing_backgroundSubstractionOn = self.backgroundSubstraction.isChecked()
-        config.GraphicsScene_livePlottingOn = self.livePlotting.isChecked()
-        config.GraphicsScene_intensTimeOn = self.intensTime.isChecked()
         config.Tracking_processNoisePosition = self.processNoisePosition.value()
         config.Tracking_processNoiseVelocity = self.processNoiseVelocity.value()
-        config.GraphicsScene_smoothPoints = self.smoothPoints.value()
-        config.GraphicsScene_smoothSpline = self.smoothSpline.value()
+        config.Tracking_gamma = self.validationRegionSize.value()
+        config.Tracking_minRsq = self.determinationCoefficient.value()
+
+        config.Processing_backgroundSubstractionOn = self.backgroundSubstraction.isChecked()
+
+        config.conf['GUI']['GraphicsScene_defaultRadius'] = str(config.GraphicsScene_defaultRadius)
+        config.conf['GUI']['GraphicsScene_livePlottingOn'] = str(config.GraphicsScene_livePlottingOn)
+        config.conf['GUI']['GraphicsScene_intensTimeOn'] = str(config.GraphicsScene_intensTimeOn)
+        config.conf['GUI']['GraphicsScene_smoothPoints'] = str(config.GraphicsScene_smoothPoints)
+        config.conf['GUI']['GraphicsScene_smoothSpline'] = str(config.GraphicsScene_smoothSpline)
+
+        config.conf['Tracking']['Tracking_inputPrecision'] = str(config.Tracking_inputPrecision)
+        config.conf['Tracking']['Tracking_windowScalingOn'] = str(config.Tracking_windowScalingOn)
+        config.conf['Tracking']['Tracking_minWindowSize'] = str(config.Tracking_minWindowSize)
+        config.conf['Tracking']['Tracking_guessFunc'] = str(config.Tracking_guessFunc)
+        config.conf['Tracking']['Tracking_processNoisePosition'] = str(config.Tracking_processNoisePosition)
+        config.conf['Tracking']['Tracking_processNoiseVelocity'] = str(config.Tracking_processNoiseVelocity)
+        config.conf['Tracking']['Tracking_gamma'] = str(config.Tracking_gamma)
+        config.conf['Tracking']['Tracking_minRsq'] = str(config.Tracking_minRsq)
+    
+        config.conf['Processing']['Processing_backgroundSubstractionOn'] = str(config.Processing_backgroundSubstractionOn)
+
+    def applyParameters(self):
+        """Parameter setting control"""
+        self.collectParameters()
+        config.saveConfig(config.configFile)
 
     def defaultValues(self):
-        """Reload config-module and get the default values"""
-        imp.reload(config)
+        # Set default acquisition parameters from configuration ini
+        config.createConfig()
+        config.readConfig(config.configFile)
+        
         self.inputPrecision.setValue(config.Tracking_inputPrecision)
         self.integrationWindowRadiusNew.setValue(config.GraphicsScene_defaultRadius)
         self.integrationWindowRadius.setValue(config.Tracking_minWindowSize)
@@ -686,43 +710,27 @@ class ParameterSettingWidget(QWidget):
         self.livePlotting.setChecked(config.GraphicsScene_livePlottingOn)
         self.processNoisePosition.setValue(config.Tracking_processNoisePosition)
         self.processNoiseVelocity.setValue(config.Tracking_processNoiseVelocity)
+        logger.info("Default acquisition parameters restored")
 
     def saveValues(self):
         """ Basic saving of the set parameter values to a file """
-        filename = qt_filedialog_convert(QFileDialog.getSaveFileName(self, "Save the parameter configuration to a file"))
-        if filename:
-            output = open(filename, 'wb')
-            writelist = [self.inputPrecision.value(), self.integrationWindowRadiusNew.value(),
-                         self.integrationWindowRadius.value(), self.validationRegionSize.value(),
-                         self.determinationCoefficient.value(), self.smoothPoints.value(),
-                         self.smoothSpline.value(), self.intensTime.isChecked(),
-                         self.integrationWindowScale.isChecked() , self.backgroundSubstraction.isChecked(),
-                         self.livePlotting.isChecked(), self.spotIdentification.currentIndex(),
-                         self.processNoisePosition.value(), self.processNoiseVelocity.value()]
-            pickle.dump(writelist, output)
-            print("Custom settings saved.")
+        
+        filename = QFileDialog.getSaveFileName(self,
+                        "Save INI config file", "","*.ini")
+        self.collectParameters()
+        config.saveConfig(filename[0])
+        print("Confguration parameters saved to:",filename[0])
+        logger.info("Confguration parameters saved to:"+filename[0])
 
     def loadValues(self):
         """ Load a file of set parameter values that has been saved with the widget """
-        filename = qt_filedialog_convert(QFileDialog.getOpenFileName(self, 'Open spot location file'))
+        
+        filename = QFileDialog.getOpenFileName(self,
+                        "Open INI config file", "","*.ini")
         try:
-            loadput = open(filename, 'rb')
-            loadlist = pickle.load(loadput)
-            self.inputPrecision.setValue(loadlist[0])
-            self.integrationWindowRadiusNew.setValue(loadlist[1])
-            self.integrationWindowRadius.setValue(loadlist[2])
-            self.validationRegionSize.setValue(loadlist[3])
-            self.determinationCoefficient.setValue(loadlist[4])
-            self.smoothPoints.setValue(loadlist[5])
-            self.smoothSpline.setValue(loadlist[6])
-            self.intensTime.setChecked(loadlist[7])
-            self.integrationWindowScale.setChecked(loadlist[8])
-            self.backgroundSubstraction.setChecked(loadlist[9])
-            self.livePlotting.setChecked(loadlist[10])
-            self.spotIdentification.setCurrentIndex(loadlist[11])
-            self.processNoisePosition.setValue(loadlist[12])
-            self.processNoiseVelocity.setValue(loadlist[13])
-            print("Custom settings restored.")
+            config.readConfig(filename)
+            print("Confguration parameters loaded from:",filename[0])
+            logger.info("Confguration parameters loaded from:"+filename[0])
         except:
             print("Invalid file")
 


### PR DESCRIPTION
Currently configuration parameters are stored in a module (defaultconfig.py). This makes parameter settings very hard to change dynamically, and requires "recompilation" of the package for any change.The proposed patch uses a parser to produce/read/save a INI file with the parameters. If it's not present already, the INI files is first created in $HOME. In the settings panel, loading and saving parameters are now done by saving copies of the INI files. Apply settings, updates the INI files as well. The INI files tracks also the app version number, so it can be used to check in the future for compatibilities in the INI file for different versions of the app.

This is a proposed patch to fix #9, and provide a much more robust and flexible way with dealing with defaults parameters.