### PR TITLE
Make clear plot button work. Restart should not clear plots.

### DIFF
--- a/source/easyleed/gui.py
+++ b/source/easyleed/gui.py
@@ -1011,7 +1011,6 @@ class MainWindow(QMainWindow):
         self.scene.removeAll()
         self.loader.restart()
         self.setImage(self.loader.next())
-        #self.plotwid.clearPlot()
         self.sliderCurrentPos = 1
         self.slider.setValue(1)
         self.fileSaveSpotsAction.setEnabled(False)

--- a/source/easyleed/gui.py
+++ b/source/easyleed/gui.py
@@ -373,8 +373,9 @@ class PlotWidget(QWidget):
 
         # Define events for checkbox
         self.averageCheck.clicked.connect(self.onAverageCheck)
-        for button in [self.smoothCheck, self.legendCheck, self.clearPlotButton]:
+        for button in [self.smoothCheck, self.legendCheck]:
             button.clicked.connect(self.updatePlot)
+        self.clearPlotButton.clicked.connect(self.clearPlot)
 
     def initPlot(self):
         # Setup axis, labels, lines, ...
@@ -457,7 +458,8 @@ class PlotWidget(QWidget):
         self.canvas.draw()
 
     def clearPlot(self):
-        self.axes.clear()
+        self.fig.clf()
+        self.axes = self.fig.add_subplot(111)
         self.initPlot()
         self.canvas.draw()
 
@@ -1009,7 +1011,7 @@ class MainWindow(QMainWindow):
         self.scene.removeAll()
         self.loader.restart()
         self.setImage(self.loader.next())
-        self.plotwid.clearPlot()
+        #self.plotwid.clearPlot()
         self.sliderCurrentPos = 1
         self.slider.setValue(1)
         self.fileSaveSpotsAction.setEnabled(False)


### PR DESCRIPTION
Currently the clear plot button is non functional. Restarting clears the plot anyway. This patch makes the buttons functionally more useful: 1. Clear button actually clears the plots. 2. Restarting does not clear the plot. This is useful when one wants to compare different extractions.

This should fix #8