### PR TITLE
Backup copy of INI and create a new one, when the ini is incompatible…

### DIFF
--- a/source/easyleed/defaultconfig.py
+++ b/source/easyleed/defaultconfig.py
@@ -7,6 +7,7 @@ Class for handling configuration settings
 import configparser, logging, os
 import numpy as np
 from pathlib import Path
+from datetime import datetime
 from . import __version__
 
 class Configuration():
@@ -79,93 +80,96 @@ class Configuration():
         self.conf.read(configFile)
         self.sysConfig = self.conf['System']
         self.appVersion = self.sysConfig['appVersion']
-        if str(self.appVersion).rsplit('.',1)[0] != __version__.rsplit('.',1)[0] :
+        try:
+            self.IOConfig = self.conf['IO']
+            self.GUIConfig = self.conf['GUI']
+            self.trackingConfig = self.conf['Tracking']
+            self.processingConfig = self.conf['Processing']
+
+            #####################
+            #### IO related ####
+            ####################
+            # regular expression to extract energy from filename (not used for img files)
+            # match the last (floating-point) number before file extension
+            self.IO_energyRegex = self.IOConfig['IO_energyRegex']
+
+            #####################
+            #### GUI related ####
+            #####################
+            ## GraphicsScene ##
+            # default radius of a new spot
+            self.GraphicsScene_defaultRadius = self.conf.getfloat('GUI', 'GraphicsScene_defaultRadius')
+            # Live IV plotting during acquisition
+            self.GraphicsScene_livePlottingOn = self.conf.getboolean('GUI', 'GraphicsScene_livePlottingOn')
+            # Acquire I(time) at fixed energy
+            self.GraphicsScene_intensTimeOn = self.conf.getboolean('GUI', 'GraphicsScene_intensTimeOn')
+            # Plot averages
+            self.GraphicsScene_plotAverage = self.conf.getboolean('GUI', 'GraphicsScene_plotAverage')
+            # Plot smoothAverages
+            self.GraphicsScene_plotSmoothAverage = self.conf.getboolean('GUI', 'GraphicsScene_plotSmoothAverage')
+            # Interval of points to be rescaled for smoothing average
+            self.GraphicsScene_smoothPoints = self.conf.getint('GUI', 'GraphicsScene_smoothPoints')
+            # Amount of smoothing to perform during the spline fit.
+            # The default value of s is s=m-\sqrt{2m} where m is the number of data-points being fit.
+            self.GraphicsScene_smoothSpline = self.conf.getint('GUI', 'GraphicsScene_smoothSpline')
+
+            ## QGraphicsMovableItem ##
+            # change in position per key press (Arrow keys)
+            self.QGraphicsMovableItem_bigMove = self.conf.getfloat('GUI', 'QGraphicsMovableItem_bigMove')
+            # change in position per key press if Ctrl pressed
+            self.QGraphicsMovableItem_smallMove = self.conf.getfloat('GUI', 'QGraphicsMovableItem_smallMove')
+
+            ## QGraphicsSpotItem ##
+            # change in radius of the spot per key press (+/-) in pixel
+            self.QGraphicsSpotItem_spotSizeChange = self.conf.getfloat('GUI', 'QGraphicsSpotItem_spotSizeChange')
+
+            ## QGraphicsCenterItem ##
+            self.QGraphicsCenterItem_size = self.conf.getfloat('GUI', 'QGraphicsCenterItem_size')
+
+            ##########################
+            #### Tracking related ####
+            ##########################
+
+            # precision of the user input (standard deviation in pixel)
+            self.Tracking_inputPrecision = self.conf.getfloat('Tracking', 'Tracking_inputPrecision')
+            # scale the integration window with changing energy
+            self.Tracking_windowScalingOn = self.conf.getboolean('Tracking', 'Tracking_windowScalingOn')
+            # minimal radius of the integration window (in pixel)
+            self.Tracking_minWindowSize = self.conf.getfloat('Tracking', 'Tracking_minWindowSize')
+            # function for spot identification
+            self.Tracking_guessFunc = self.trackingConfig['Tracking_guessFunc']
+            # Kalman tracker process noise
+            self.Tracking_processNoisePosition = self.conf.getfloat('Tracking', 'Tracking_processNoisePosition')
+            self.Tracking_processNoiseVelocity = self.conf.getfloat('Tracking', 'Tracking_processNoiseVelocity')
+            # size of validation region
+            # Ideal assumptions D_M^2 ~ Chi^2 with two degrees of freedom
+            # cdf Chi^2 with two degrees of freedom is 1 - exp(-x/2)
+            self.Tracking_gamma = self.conf.getfloat('Tracking', 'Tracking_gamma')
+            # Minimal coefficient of determination R^2 for fit
+            self.Tracking_minRsq = self.conf.getfloat('Tracking', 'Tracking_minRsq')
+            # factor by which the fitted region is bigger than the radius
+            self.Tracking_fitRegionFactor = self.conf.getfloat('Tracking', 'Tracking_fitRegionFactor')
+
+            ############################
+            #### Processing related ####
+            ############################
+            # substract the background from the intensity measurements
+            self.Processing_backgroundSubstractionOn = self.conf.getboolean('Processing', 'Processing_backgroundSubstractionOn')
+        
+            ############################
+            #### System related ####
+            ############################
+            self.loggingLevel = self.conf.getint('System', 'loggingLevel')
+    
+        except:
             print("Configuration file is for an earlier version of the software")
-            oldConfigFile = str(os.path.splitext(configFile)[0]+"_"+str(self.appVersion)+".ini")
+            oldConfigFile = str(os.path.splitext(configFile)[0] + "_" +\
+                    str(datetime.now().strftime('%Y%m%d-%H%M%S'))+".ini")
             print("Old config file backup: ",oldConfigFile)
             os.rename(configFile, oldConfigFile )
             print("Creating a new config file.")
             self.createConfig()
-            
-        self.IOConfig = self.conf['IO']
-        self.GUIConfig = self.conf['GUI']
-        self.trackingConfig = self.conf['Tracking']
-        self.processingConfig = self.conf['Processing']
-
-        #####################
-        #### IO related ####
-        ####################
-        # regular expression to extract energy from filename (not used for img files)
-        # match the last (floating-point) number before file extension
-        self.IO_energyRegex = self.IOConfig['IO_energyRegex']
-
-        #####################
-        #### GUI related ####
-        #####################
-        ## GraphicsScene ##
-        # default radius of a new spot
-        self.GraphicsScene_defaultRadius = self.conf.getfloat('GUI', 'GraphicsScene_defaultRadius')
-        # Live IV plotting during acquisition
-        self.GraphicsScene_livePlottingOn = self.conf.getboolean('GUI', 'GraphicsScene_livePlottingOn')
-        # Acquire I(time) at fixed energy
-        self.GraphicsScene_intensTimeOn = self.conf.getboolean('GUI', 'GraphicsScene_intensTimeOn')
-        # Plot averages
-        self.GraphicsScene_plotAverage = self.conf.getboolean('GUI', 'GraphicsScene_plotAverage')
-        # Plot smoothAverages
-        self.GraphicsScene_plotSmoothAverage = self.conf.getboolean('GUI', 'GraphicsScene_plotSmoothAverage')
-        # Interval of points to be rescaled for smoothing average
-        self.GraphicsScene_smoothPoints = self.conf.getint('GUI', 'GraphicsScene_smoothPoints')
-        # Amount of smoothing to perform during the spline fit.
-        # The default value of s is s=m-\sqrt{2m} where m is the number of data-points being fit.
-        self.GraphicsScene_smoothSpline = self.conf.getint('GUI', 'GraphicsScene_smoothSpline')
-
-        ## QGraphicsMovableItem ##
-        # change in position per key press (Arrow keys)
-        self.QGraphicsMovableItem_bigMove = self.conf.getfloat('GUI', 'QGraphicsMovableItem_bigMove')
-        # change in position per key press if Ctrl pressed
-        self.QGraphicsMovableItem_smallMove = self.conf.getfloat('GUI', 'QGraphicsMovableItem_smallMove')
-
-        ## QGraphicsSpotItem ##
-        # change in radius of the spot per key press (+/-) in pixel
-        self.QGraphicsSpotItem_spotSizeChange = self.conf.getfloat('GUI', 'QGraphicsSpotItem_spotSizeChange')
-
-        ## QGraphicsCenterItem ##
-        self.QGraphicsCenterItem_size = self.conf.getfloat('GUI', 'QGraphicsCenterItem_size')
-
-        ##########################
-        #### Tracking related ####
-        ##########################
-
-        # precision of the user input (standard deviation in pixel)
-        self.Tracking_inputPrecision = self.conf.getfloat('Tracking', 'Tracking_inputPrecision')
-        # scale the integration window with changing energy
-        self.Tracking_windowScalingOn = self.conf.getboolean('Tracking', 'Tracking_windowScalingOn')
-        # minimal radius of the integration window (in pixel)
-        self.Tracking_minWindowSize = self.conf.getfloat('Tracking', 'Tracking_minWindowSize')
-        # function for spot identification
-        self.Tracking_guessFunc = self.trackingConfig['Tracking_guessFunc']
-        # Kalman tracker process noise
-        self.Tracking_processNoisePosition = self.conf.getfloat('Tracking', 'Tracking_processNoisePosition')
-        self.Tracking_processNoiseVelocity = self.conf.getfloat('Tracking', 'Tracking_processNoiseVelocity')
-        # size of validation region
-        # Ideal assumptions D_M^2 ~ Chi^2 with two degrees of freedom
-        # cdf Chi^2 with two degrees of freedom is 1 - exp(-x/2)
-        self.Tracking_gamma = self.conf.getfloat('Tracking', 'Tracking_gamma')
-        # Minimal coefficient of determination R^2 for fit
-        self.Tracking_minRsq = self.conf.getfloat('Tracking', 'Tracking_minRsq')
-        # factor by which the fitted region is bigger than the radius
-        self.Tracking_fitRegionFactor = self.conf.getfloat('Tracking', 'Tracking_fitRegionFactor')
-
-        ############################
-        #### Processing related ####
-        ############################
-        # substract the background from the intensity measurements
-        self.Processing_backgroundSubstractionOn = self.conf.getboolean('Processing', 'Processing_backgroundSubstractionOn')
-        
-        ############################
-        #### System related ####
-        ############################
-        self.loggingLevel = self.conf.getint('System', 'loggingLevel')
+            self.readConfig(configFile)
 
     # Save current parameters in configuration file
     def saveConfig(self, configFile):


### PR DESCRIPTION
… with current version

In order to prevent a crash when the user has a INI file from a previous version of Easyleed, the INI file is backed up with a time stamp and a new one is created.