### PR TITLE
Fix crash when deselecting average plot after clearing plot

### DIFF
--- a/source/easyleed/gui.py
+++ b/source/easyleed/gui.py
@@ -419,7 +419,8 @@ class PlotWidget(QWidget):
         """ Basic Matplotlib plotting I(E)-curve """
         for spot, line in six.iteritems(self.lines_map):
             line.set_data(self.worker.spots_map[spot][0].m.energy, self.worker.spots_map[spot][0].m.intensity)
-        if self.averageCheck.isChecked():
+        
+        if self.averageCheck.isChecked() and len(self.axes.lines) > 1:
             intensity = np.zeros(self.worker.numProcessed())
             for model, tracker in six.itervalues(self.worker.spots_map):
                 intensity += model.m.intensity
@@ -446,8 +447,11 @@ class PlotWidget(QWidget):
                     del self.averageSmoothLine
         else:
             if hasattr(self, "averageLine"):
-                self.averageLine.remove()
-                del self.averageLine
+                try:
+                    self.averageLine.remove()
+                    del self.averageLine
+                except:
+                    pass
 
         if self.axes.legend() is not None:
             # decide whether to show legend
@@ -460,6 +464,8 @@ class PlotWidget(QWidget):
         self.canvas.draw()
 
     def clearPlot(self):
+        self.averageCheck.setChecked(False)
+        self.updatePlot()
         self.fig.clf()
         self.axes = self.fig.add_subplot(111)
         self.initPlot()


### PR DESCRIPTION
Currently, the deselecting average after clearning a plot crashes easyleed. The patch unchecks the "average" checkbox after clearing the plot, and makes sure the average is preserved and plotted for a clean plot. It also fixes the average not appearing after a second replot.