### PR TITLE
Replace spot and center locations save/load methods with csv through …

### DIFF
--- a/source/easyleed/gui.py
+++ b/source/easyleed/gui.py
@@ -1206,30 +1206,31 @@ class MainWindow(QMainWindow):
         """Load Spots location from csv file"""
         filename = qt_filedialog_convert(QFileDialog.getOpenFileName(self, 'Open spot location file'))
         if filename:
-            if os.path.splitext(filename)[1] == ".csv":
-                df = pd.read_csv(filename, skipinitialspace=True)
-                energy = df['Energy'].tolist()
-                numSpots = int((len(df.columns)-1)/3)
-                locationx = [df['x #'+str(s+1)].tolist() for s in range(numSpots)]
-                locationy = [df['y #'+str(s+1)].tolist() for s in range(numSpots)]
-                radius = [df['r #'+str(s+1)].tolist() for s in range(numSpots)]
-                # NEED TO FIGURE OUT HOW TO GET ALL THE SPOTS TO RESPECTIVE ENERGIES, now only loads the first energy's spots
-                # improving might involve modifying the algorithm for calculating intensity
-            else:
-                print("Old format for spot locations file detected...")
-                with open(filename, 'rb') as pkl_file:
-                    location = pickle.load(pkl_file)
-                energy, locationx, locationy, radius = zip(*location)
-                numSpots = len(energy)
+            try:
+                if os.path.splitext(filename)[1] == ".csv":
+                    df = pd.read_csv(filename, skipinitialspace=True)
+                    energy = df['Energy'].tolist()
+                    numSpots = int((len(df.columns)-1)/3)
+                    locationx = [df['x #'+str(s+1)].tolist() for s in range(numSpots)]
+                    locationy = [df['y #'+str(s+1)].tolist() for s in range(numSpots)]
+                    radius = [df['r #'+str(s+1)].tolist() for s in range(numSpots)]
+                    # NEED TO FIGURE OUT HOW TO GET ALL THE SPOTS TO RESPECTIVE ENERGIES, now only loads the first energy's spots
+                    # improving might involve modifying the algorithm for calculating intensity
+                else:
+                    with open(filename, 'rb') as pkl_file:
+                        location = pickle.load(pkl_file)
+                    energy, locationx, locationy, radius = zip(*location)
+                    numSpots = len(energy)
             
-            self.scene.removeAll()
-            for i in range(numSpots):
-                #for j in range(len(energy[i])):
-                # only taking the first energy location, [0] -> [j] for all, but now puts every spot to the first energy
-                point = QPointF(locationx[i][0], locationy[i][0])
-                item = QGraphicsSpotItem(point, radius[i][0])
-                # adding the item to the gui
-                self.scene.addSpot(item)
+                self.scene.removeAll()
+                for i in range(numSpots):
+                    # only taking the first energy location, [0] -> [j] for all, but now puts every spot to the first energy
+                    point = QPointF(locationx[i][0], locationy[i][0])
+                    item = QGraphicsSpotItem(point, radius[i][0])
+                    # adding the item to the gui
+                    self.scene.addSpot(item)
+            except:
+                print("Invalid file for spot locations...")
 
     def saveCenter(self):
         """Saves the center locations to a file, uses workers saveCenter-method"""
@@ -1245,28 +1246,30 @@ class MainWindow(QMainWindow):
         """Load Center location from csv file"""
         filename = qt_filedialog_convert(QFileDialog.getOpenFileName(self, 'Open spot location file'))
         if filename:
-            if os.path.splitext(filename)[1] == ".csv":
-                df = pd.read_csv(filename, skipinitialspace=True)
-                cLocx = [df['Center x'].tolist()]
-                cLocy = [df['Center y'].tolist()]
-            else:
-                print("Old format for center locations file detected...")
-                # pickle doesn't recognise the file opened by PyQt's openfile dialog as a file so 'normal' file processing
-                with open(filename, 'rb') as pkl_file:
-                    location = pickle.load(pkl_file)
-                cLocx, cLocy = zip(*location)
-            
-            self.scene.removeCenter()
-            point = QPointF(cLocx[0][0], cLocy[0][0])
-            item = QGraphicsCenterItem(point, config.QGraphicsCenterItem_size)
-            # adding the item to the gui
-            self.scene.clearSelection()
-            self.scene.addItem(item)
-            item.setSelected(True)
-            self.scene.center = item
-            self.scene.setFocusItem(item)
-            self.fileSaveCenterAction.setEnabled(True)
-
+            try:
+                if os.path.splitext(filename)[1] == ".csv":
+                    df = pd.read_csv(filename, skipinitialspace=True)
+                    cLocx = df['Center x'].tolist()
+                    cLocy = df['Center y'].tolist()
+                else:
+                    # pickle doesn't recognise the file opened by PyQt's openfile dialog as a file so 'normal' file processing
+                    with open(filename, 'rb') as pkl_file:
+                        location = pickle.load(pkl_file)
+                    cLocx, cLocy = zip(*location)
+                
+                self.scene.removeCenter()
+                point = QPointF(cLocx[0], cLocy[0])
+                item = QGraphicsCenterItem(point, config.QGraphicsCenterItem_size)
+                # adding the item to the gui
+                self.scene.clearSelection()
+                self.scene.addItem(item)
+                item.setSelected(True)
+                self.scene.center = item
+                self.scene.setFocusItem(item)
+                self.fileSaveCenterAction.setEnabled(True)
+            except:
+                print("Invalid file for center location...")
+                
 class Worker(QObject):
     """ Worker that manages the spots.
 

--- a/source/easyleed/gui.py
+++ b/source/easyleed/gui.py
@@ -1339,8 +1339,11 @@ class Worker(QObject):
                 'r #'+str(s+1) : [self.spots_map[spots[s]][0].m.radius[i] for i in range(numEnergies)]}))
 
         # Save Center coordinates in dataframe
-        self.pdframe['Center x'] = self.parent().scene.center.x()
-        self.pdframe['Center y'] = self.parent().scene.center.y()
+        if hasattr(self.parent().scene.center, "x"):
+            self.pdframe['Center x'] = self.parent().scene.center.x()
+            self.pdframe['Center y'] = self.parent().scene.center.y()
+        else:
+            pass
         self.pdframe['Background substraction'] = bs
 
     def saveIntensity(self, filename):


### PR DESCRIPTION
…dataframe

Currently, saving and loading from file spot and center locations are done with pickle using binary files. These are inconveniently useful only to reload them up in Easyleed. This patch uses the internal dataframe to export the locations into a CSV file. This allows for full modification of the file, and more transparent handling of the parameters.